### PR TITLE
Fix CSS link in home layout

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>{{ site.title }}</title>
-    <link rel="stylesheet" href="{{ '/assets:css/style.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- correct stylesheet path in home.html

## Testing
- `jekyll build` *(fails: jekyll-remote-theme not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fe17b08d88323a1db465fcb0c7d89